### PR TITLE
Actualiza el link a Slack en _index.md

### DIFF
--- a/content/es/authors/MetaDocencia/_index.md
+++ b/content/es/authors/MetaDocencia/_index.md
@@ -28,7 +28,7 @@ social:
   link: https://github.com/MetaDocencia
 - icon: slack
   icon_pack: fab
-  link: https://join.slack.com/t/metadocencia/shared_invite/zt-ek8a0rup-MQB_5qUKhr9zIGKQAUImXA
+  link: https://join.slack.com/t/metadocencia/shared_invite/zt-1a3cri0ht-_Ws~Eq2VkkQ9L64rvu2czA
 superuser: true
 user_groups:
 ---


### PR DESCRIPTION
Corrigiendo el link roto en esa parte del sitio - Laura ya lo había arreglado en `params.toml` ([aquí](https://github.com/MetaDocencia/SitioWeb/commit/a1f729ec61332055ebd7ef9d444395ad136984fc)).

Resuelve parcialmente https://github.com/MetaDocencia/SitioWeb/issues/92.